### PR TITLE
Add firebase.py, que inicia o serviço firebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ serviceAccount.json
 config.json
 tmp/
 *.oga
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ venv.bak/
 .mypy_cache/
 
 #config
+serviceAccount.json
 config.json
 tmp/
 *.oga

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 ## Running
 To run the application in development mode run:
   ```docker-compose up```
+PS. 
+You need to create a serviceAccount.json file at the root folder with a service account from google cloud to configure Firebase.
+Also, you need to create a config.json file in the root folder with two keys:
+- telegram_token: <the telegram api token>
+- google_application_credentials: serviceAccount.json

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 To run the application in development mode run:
   ```docker-compose up```
 PS. 
-You need to create a serviceAccount.json file at the root folder with a service account from google cloud to configure Firebase.
-Also, you need to create a config.json file in the root folder with two keys:
-- telegram_token: <the telegram api token>
-- google_application_credentials: serviceAccount.json
+You need to create a `serviceAccount.json` file at the root folder with a service account from google cloud to configure Firebase.
+Also, you need to create a `config.json` file in the root folder with two keys:
+- telegram_token: `the telegram api token`
+- google_application_credentials: `serviceAccount.json`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-telegram-bot
 requests
+firebase_admin

--- a/src/app.py
+++ b/src/app.py
@@ -8,20 +8,23 @@ from handlers.audio import audio_handler
 
 from logger import config_logger
 from constants import *
+
 import config
+import firebase
+
 
 def init():
     config_logger()
-    
+
     updater = Updater(token=config.get(TELEGRAM_TOKEN))
     dispatcher = updater.dispatcher
-    
+
     # add handlers
     dispatcher.add_handler(text_handler())
     dispatcher.add_handler(audio_handler())
 
     updater.start_polling()
-
     logging.info("Bot is listening for messages...")
+
 
 init()

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,9 @@
 import json
 from constants import *
 
-with open(CONFIG_FILE) as json_file:  
+with open(CONFIG_FILE) as json_file:
     data = json.load(json_file)
-    
+
+
 def get(key):
     return data[key]

--- a/src/constants.py
+++ b/src/constants.py
@@ -7,3 +7,5 @@ VOICE = "voice"
 PATH = "tmp/audios/"
 AUDIO_EXTENSION = ".oga"
 FILE_ID = "file_id"
+GOOGLE_APPLICATION_CREDENTIALS = "google_application_credentials"
+

--- a/src/firebase.py
+++ b/src/firebase.py
@@ -1,0 +1,10 @@
+import firebase_admin
+from firebase_admin import credentials
+from firebase_admin import firestore
+import config
+
+# Use a service account
+cred = credentials.Certificate(config.get("google_application_credentials"))
+firebase_admin.initialize_app(cred)
+
+db = firestore.client()


### PR DESCRIPTION
firebase.py inicia o serviço Firebase. Para ter a referencia do db, basta dar um `import firebase` e acessar `firebase.db`. É um cloud firestore, então para fazer as ações pode seguir essa referência https://firebase.google.com/docs/firestore/quickstart

No Firebase, existe uma collection "servers" que cada documento é o UID dos servidores do telegram que utilizam o bot, contendo, dentro desse documento, uma propriedade "words", que é um array de palavras que o servidor deseja censurar.