### PR TITLE
Implement text filter

### DIFF
--- a/src/handlers/text.py
+++ b/src/handlers/text.py
@@ -1,12 +1,40 @@
+from firebase import get_banned_words
 from telegram.ext import MessageHandler, Filters
 from constants import *
 import logging
+import unicodedata
+
+
+def remove_accents(word):
+    return "".join(
+        (
+            c
+            for c in unicodedata.normalize("NFD", word)
+            if unicodedata.category(c) != "Mn"
+        )
+    )
+
+
+def clean_word(word):
+    return remove_accents(word).lower()
 
 
 def __watch(update, context):
     message = context[MESSAGE]
     chat = message[CHAT]
     text = message[TEXT]
+
+    banned_words = get_banned_words(str(chat.id))
+    cleared_words = map(clean_word, banned_words)
+
+    banned_words_dict = dict.fromkeys(cleared_words, True)
+
+    textWords = text.split()
+
+    for word in textWords:
+        if banned_words_dict.get(clean_word(word)):
+            message.delete()
+            break
 
     logging.info(chat)
     logging.info(text)


### PR DESCRIPTION
O filtro remove os acentos das palavras que foram banidas e as deixa em minúsculo. Depois, se faz uma comparação com a palavra que foi mandada pelo usuário (que também é aplicada o remover acento) e checa se ela está na lista de palavras banidas. Exclui-se a mensagem em caso positivo. 